### PR TITLE
Fix code so it runs

### DIFF
--- a/python/load_xml.py
+++ b/python/load_xml.py
@@ -71,9 +71,9 @@ def getXmlForPartition(partition):
 udfGetXml = udf(getXml, StringType())
 
 if args.format == "parquet":
-    input = spark.read.parquet(*args.input) 
+    input = spark.read.parquet(args.input)
 elif args.format == "csv":
-    input = spark.read.csv(*args.input, header=True) 
+    input = spark.read.csv(args.input, header=True)
 else:
     raise Exception("Unexpected input format \"%s\"" % args.input)
 

--- a/python/merge_xml.py
+++ b/python/merge_xml.py
@@ -18,8 +18,8 @@ LOGGER = log4jLogger.LogManager.getLogger(__name__)
 ### Handle command line arguments
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--input", action="append", help="Path to Parquet file containing xpath-value pairs.")
-parser.add_argument("--output", action="store", help="Path in which to store result. Can be local or S3.")
+parser.add_argument("--input", action="store", help="Path to Parquet file containing xpath-value pairs.", default="990_long/parsed")
+parser.add_argument("--output", action="store", help="Path in which to store result. Can be local or S3.", default="")
 parser.add_argument("--timestamp", action="store_true", help="If true, append the timestamp to the output path.")
 parser.add_argument("--partitions", type=int, action="store", help="Number of partitions to use for the join.", default=400)
 args = parser.parse_known_args()[0]

--- a/python/merge_xml.py
+++ b/python/merge_xml.py
@@ -42,7 +42,7 @@ cc = spark.read.csv("concordance.csv", header=True) \
                 col("location_code").alias("location"))
 
 standardize = udf(lambda xpath : "/Return/" + xpath.strip(), StringType())
-df = spark.read.parquet(*args.input) \
+df = spark.read.parquet(args.input) \
         .repartition(args.partitions) \
         .withColumn("xpath", standardize(col("xpath"))) \
 

--- a/python/parse_xml.py
+++ b/python/parse_xml.py
@@ -19,7 +19,7 @@ LOGGER = log4jLogger.LogManager.getLogger(__name__)
 ### Handle command line arguments
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--input", action="append", help="Path to Parquet file containing raw XML. Can supply multiple.")
+parser.add_argument("--input", action="store", help="Path to Parquet file containing raw XML. Can supply multiple.", default="990_long/xml")
 parser.add_argument("--output", action="store", help="Path in which to store result. Can be local or S3.", default="990_long/parsed")
 parser.add_argument("--timestamp", action="store_true", help="If true, append the timestamp to the output path.")
 parser.add_argument("--partitions", type=int, action="store", help="Number of partitions to use for XML parsing.", default=500)

--- a/python/parse_xml.py
+++ b/python/parse_xml.py
@@ -97,7 +97,7 @@ schema = ArrayType(
 
 udfParse = udf(parse, schema)
 
-spark.read.parquet(*args.input) \
+spark.read.parquet(args.input) \
         .repartition(args.partitions) \
         .withColumn("elementArr", udfParse("XML")) \
         .select(col("dln"),

--- a/python/split_csv.py
+++ b/python/split_csv.py
@@ -18,7 +18,7 @@ LOGGER = log4jLogger.LogManager.getLogger(__name__)
 ### Handle command line arguments
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--input", action="store", help="Path to Parquet file containing xpath-value pairs.", default = "990_long/parsed")
+parser.add_argument("--input", action="store", help="Path to Parquet file containing merged xml.", default = "")
 parser.add_argument("--output", action="store", help="Path in which to store CSVs. Can be local or S3. Local recommended.", default = "990_long/csv")
 parser.add_argument("--timestamp", action="store_true", help="If true, append the timestamp to the output path.")
 args = parser.parse_known_args()[0]


### PR DESCRIPTION
Fixes #3 

There was some strange unpacking of `args.input`, so that instead of looking for the file `990_long/paths` it was looking for a file named `9` (which did not exist).

This may have been related to the fact that `action="append"` was used in some places, which would have created a one-element list containing the input string. I was able to run the code after making these changes (although I understand it's no longer a recommended way to work with 990 data).

Note that even after these changes, the split_csv job appeared to get stuck at 10%:
```
[hadoop@ip-10-0-3-135 990_long]$ yarn application -list
18/08/24 21:50:01 INFO impl.TimelineClientImpl: Timeline service address: http://ip-10-0-3-135.us-west-2.compute.internal:8188/ws/v1/timeline/
18/08/24 21:50:01 INFO client.RMProxy: Connecting to ResourceManager at ip-10-0-3-135.us-west-2.compute.internal/10.0.3.135:8032
Total number of applications (application-types: [] and states: [SUBMITTED, ACCEPTED, RUNNING]):1
                Application-Id	    Application-Name	    Application-Type	      User	     Queue	             State	       Final-State	       Progress	                       Tracking-URL
application_1535142416668_0011	        split_csv.py	               SPARK	    hadoop	   default	           RUNNING	         UNDEFINED	            10%	http://ip-10-0-3-135.us-west-2.compute.internal:4040
```